### PR TITLE
Python 2 -> 3 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Simply clone the repository, build the Elm app and serve it in your favorite man
 $ git clone https://github.com/ohanhi/elm-shared-state.git
 $ cd elm-shared-state
 $ elm make src/Main.elm --output=elm.js
-$ python -m SimpleHTTPServer 8000
+$ python3 -m http.server 8000
 ```
 
 


### PR DESCRIPTION
On Arch (and others), `python` without a number is Python 3 which `SimpleHTTPServer` doesn't work for. It's better to use the latest Python 3 with the version number tacked to it so there isn't a failure when copy-pasting this.