### PR TITLE
Updated dependencies because of package name change

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
@@ -16,14 +16,14 @@
             "elm/url": "1.0.0",
             "krisajenkins/remotedata": "5.0.0",
             "ohanhi/remotedata-http": "3.0.0",
-            "rtfeldman/elm-css": "16.0.0",
+            "rtfeldman/elm-css": "17.0.5",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2",
             "ryannhg/date-format": "2.3.0"
         },
         "indirect": {
-            "Skinney/murmur3": "2.0.8",
             "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.2",
+            "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"
         }
     },


### PR DESCRIPTION
Updated 'rtfeldman/elm-css' to 17.0.5 because of a name change of an
indirect dependency. `Skinney/murmur3` is now `robinheghan/murmur3`. The
old version cannot be downloaded any more and this causes `elm make` to fail.